### PR TITLE
chore: add npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.github/*
+/src


### PR DESCRIPTION
Adds a `.npmignore` file to exclude development-only files (like `/src`) from the published npm package, reducing its size.

The `src` folder is not required for production usage, as users only need the compiled `dist` folder.
